### PR TITLE
Enable dll to be called in a powershell script

### DIFF
--- a/lighthouse.net/Core/WhereCmd.cs
+++ b/lighthouse.net/Core/WhereCmd.cs
@@ -7,7 +7,7 @@ namespace lighthouse.net.Core
 {
     internal sealed class WhereCmd : TerminalBase
     {
-        protected override string FileName => "where";
+        protected override string FileName => "where.exe";
         internal async Task<string> GetNodePath()
         {
             return await this.Execute("node");


### PR DESCRIPTION
When an application using the library is called from powershell, the where command issued to check for node existence is interpreted as the powershell where command instead of where.exe app.