### PR TITLE
Implement OnlyCategories options

### DIFF
--- a/lighthouse.net.tests/NpmTests.cs
+++ b/lighthouse.net.tests/NpmTests.cs
@@ -16,6 +16,21 @@ namespace lighthouse.net.tests
             Assert.IsNotNull(res);
             Assert.IsNotNull(res.Performance);
             Assert.IsTrue(res.Performance > 0.5m);
+            Assert.IsTrue(res.Accessibility > 0.5m);
+        }
+
+        [TestMethod]
+        public void OnlyCategoriesTest()
+        {
+            var lh = new Lighthouse();
+            var ar = new AuditRequest("http://example.com");
+            ar.OnlyCategories = new string[]{ "performance" };
+            var res = lh.Run(ar).Result;
+
+            Assert.IsNotNull(res);
+            Assert.IsNotNull(res.Performance);
+            Assert.IsTrue(res.Performance > 0.5m);
+            Assert.IsNull(res.Accessibility);
         }
     }
 }

--- a/lighthouse.net/Core/LighthouseJsOptions.cs
+++ b/lighthouse.net/Core/LighthouseJsOptions.cs
@@ -13,6 +13,8 @@ namespace lighthouse.net.Core
         public bool? disableDeviceEmulation { get; set; }
         public string emulatedFormFactor { get; set; }
 
+        public string[] onlyCategories { get; set; }
+
         public ThrottlingSettings throttling { get; set;}
 
         internal sealed class ThrottlingSettings

--- a/lighthouse.net/Core/ScriptMaker.cs
+++ b/lighthouse.net/Core/ScriptMaker.cs
@@ -28,7 +28,8 @@ namespace lighthouse.net.Core
                 blockedUrlPatterns = request.BlockedUrlPatterns,
                 disableStorageReset = request.DisableStorageReset,
                 disableDeviceEmulation = request.DisableDeviceEmulation,
-                emulatedFormFactor = request.EmulatedFormFactor?.ToString().ToLower()
+                emulatedFormFactor = request.EmulatedFormFactor?.ToString().ToLower(),
+                onlyCategories = request.OnlyCategories
             };
 
             var optionsAsJson = JsonConvert.SerializeObject(jsOptions,

--- a/lighthouse.net/Objects/AuditRequest.cs
+++ b/lighthouse.net/Objects/AuditRequest.cs
@@ -43,11 +43,17 @@ namespace lighthouse.net.Objects
 
         public bool EnableLogging { get; set; }
 
+        /// <summary>
+        /// Only run the specified categories. Available categories: accessibility, best-practices, performance, pwa, seo
+        /// </summary>
+        public string[] OnlyCategories { get; set; }
+
         public enum FormFactor : byte
         {
             Mobile,
             Desktop,
             None
         }
+
     }
 }

--- a/lighthouse.net/lighthouse.net.csproj
+++ b/lighthouse.net/lighthouse.net.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
In order to speed up tests where I need only the performance metrics I've implemented the "OnlyCategories" option.

I also had to include the Microsoft.CSharp nuget package as this appeared to be a broken dependency when I tried to build.