### PR TITLE
Form factor

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.cs]
+
+# S112: General exceptions should never be thrown
+dotnet_diagnostic.S112.severity = none

--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ public class LighthouseTest
     }
 }
 ```
+
+
+### Known Issues
+- If you installed lighthouse package with version 9.0.0 and higher it's required to use Node.js version 14 (because Optional Chaining Operator is used in lighthouse package). To install lighthouse package, that supports Node.js v12 please use `npm i lighthouse@8.6.0 -g`

--- a/lighthouse.net.sln
+++ b/lighthouse.net.sln
@@ -1,11 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.156
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "lighthouse.net", "lighthouse.net\lighthouse.net.csproj", "{2762BE53-7E00-4BD2-8B3F-7C699424B7F2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "lighthouse.net", "lighthouse.net\lighthouse.net.csproj", "{2762BE53-7E00-4BD2-8B3F-7C699424B7F2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "lighthouse.net.tests", "lighthouse.net.tests\lighthouse.net.tests.csproj", "{11C90C03-CFDF-45BB-9044-BBBB83081EA0}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{03A5C269-86A1-4EB2-9517-5F9042B296DA}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/lighthouse.net.tests/NpmTests.cs
+++ b/lighthouse.net.tests/NpmTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using lighthouse.net.Objects;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static lighthouse.net.Objects.AuditRequest;
 
 namespace lighthouse.net.tests
 {
@@ -64,6 +65,20 @@ namespace lighthouse.net.tests
             Assert.IsNotNull(res.Thumbnails);
             Assert.IsFalse(res.Thumbnails.Count == 0);
             Assert.IsFalse(String.IsNullOrWhiteSpace(res.Thumbnails[0].Base64Data));
+        }
+  
+        [TestMethod]
+        public async Task FormFactorTest()
+        {
+            var lh = new Lighthouse();
+            var ar = new AuditRequest("http://example.com")
+            {
+                EmulatedFormFactor = FormFactor.Desktop
+            };
+
+            var res = await lh.Run(ar);
+
+            Assert.IsNotNull(res);
         }
     }
 }

--- a/lighthouse.net.tests/lighthouse.net.tests.csproj
+++ b/lighthouse.net.tests/lighthouse.net.tests.csproj
@@ -56,6 +56,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\.editorconfig">
+      <Link>.editorconfig</Link>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/lighthouse.net/Core/ILogger.cs
+++ b/lighthouse.net/Core/ILogger.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace lighthouse.net.Core
+﻿namespace lighthouse.net.Core
 {
     internal interface ILogger
     {

--- a/lighthouse.net/Core/LighthouseJsOptions.cs
+++ b/lighthouse.net/Core/LighthouseJsOptions.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using lighthouse.net.Objects;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace lighthouse.net.Core
 {
@@ -15,7 +12,14 @@ namespace lighthouse.net.Core
         public IEnumerable<string> blockedUrlPatterns { get; set;}
         public bool? disableStorageReset { get; set;}
         public bool? disableDeviceEmulation { get; set; }
+        /// <summary>
+        /// For LH < version 7.0
+        /// </summary>
         public string emulatedFormFactor { get; set; }
+        /// <summary>
+        /// For LH >= version 7.0
+        /// </summary>
+        public string preset { get; set; }
         
         [JsonIgnore]
         public IEnumerable<Category> OnlyCategories {get; set;}

--- a/lighthouse.net/Core/Logger.cs
+++ b/lighthouse.net/Core/Logger.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 
 namespace lighthouse.net.Core
 {
@@ -9,18 +7,19 @@ namespace lighthouse.net.Core
     {
         private readonly string _tempDirectory;
         private readonly string _fileName;
+        private readonly object lockObj = new object();
+
         internal Logger(string name)
         {
             this._tempDirectory = Path.GetTempPath();
             this._fileName = $"{name}-{Guid.NewGuid():N}.txt";
         }
 
-
         public bool Append(string content)
         {
             try
             {
-                lock (this)
+                lock (lockObj)
                 {
                     File.AppendAllText(_tempDirectory + _fileName, content);
                 }
@@ -28,6 +27,7 @@ namespace lighthouse.net.Core
             }
             catch
             {
+                // ignore
             }
             return false;
         }

--- a/lighthouse.net/Core/Node.cs
+++ b/lighthouse.net/Core/Node.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace lighthouse.net.Core

--- a/lighthouse.net/Core/Node.cs
+++ b/lighthouse.net/Core/Node.cs
@@ -11,7 +11,7 @@ namespace lighthouse.net.Core
         protected override string FileName => "node";
         public async Task<string> Run(string jsFilePath)
         {
-            return await this.Execute(jsFilePath).ConfigureAwait(false);
+            return await this.Execute("--harmony --unhandled-rejections=strict " + jsFilePath).ConfigureAwait(false);
         }
         protected override void OnError(string message)
         {

--- a/lighthouse.net/Core/Npm.cs
+++ b/lighthouse.net/Core/Npm.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using lighthouse.net.Objects;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
@@ -22,6 +23,13 @@ namespace lighthouse.net.Core
             var rsp = await this.Execute("config get prefix");
             if (String.IsNullOrEmpty(rsp)) throw new Exception("Couldn't detect global node_modules path.");
             return rsp.Trim();
+        }
+        internal async Task<NpmPackageVersion> GetLighthouseVersion()
+        {
+            var rsp = await this.Execute("list -g --depth=0 | find \"lighthouse\"");
+            var index = !String.IsNullOrEmpty(rsp) ? rsp.IndexOf("@") : -1;
+            if (index == -1) throw new Exception("Couldn't detect lighthouse version.");
+            return new NpmPackageVersion(rsp.Substring(index + 1).Trim());
         }
         protected override void OnError(string message)
         {

--- a/lighthouse.net/Core/Npm.cs
+++ b/lighthouse.net/Core/Npm.cs
@@ -1,7 +1,5 @@
 ﻿using lighthouse.net.Objects;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace lighthouse.net.Core
@@ -28,7 +26,7 @@ namespace lighthouse.net.Core
         {
             var rsp = await this.Execute("list -g --depth=0 | find \"lighthouse\"");
             var index = !String.IsNullOrEmpty(rsp) ? rsp.IndexOf("@") : -1;
-            if (index == -1) throw new Exception("Couldn't detect lighthouse version.");
+            if (rsp == null || index == -1) throw new Exception("Couldn't detect lighthouse version.");
             return new NpmPackageVersion(rsp.Substring(index + 1).Trim());
         }
         protected override void OnError(string message)

--- a/lighthouse.net/Core/ScriptMaker.cs
+++ b/lighthouse.net/Core/ScriptMaker.cs
@@ -12,7 +12,7 @@ namespace lighthouse.net.Core
         {
         }
 
-        internal string Produce(AuditRequest request, string npmPath)
+        internal string Produce(AuditRequest request, string npmPath, NpmPackageVersion lighthouseVersion)
         {
             if (request == null) return null;
             var data = this.getTemplate();
@@ -33,6 +33,12 @@ namespace lighthouse.net.Core
 
                 emulatedFormFactor = request.EmulatedFormFactor?.ToString().ToLower()
             };
+            // https://github.com/GoogleChrome/lighthouse/blob/master/docs/emulation.md
+            if (lighthouseVersion.MajorVersion >= 7)
+            {
+                jsOptions.preset = jsOptions.emulatedFormFactor;
+                jsOptions.emulatedFormFactor  = null;
+            }
 
             var optionsAsJson = JsonConvert.SerializeObject(jsOptions,
                 Formatting.None,

--- a/lighthouse.net/Core/ScriptMaker.cs
+++ b/lighthouse.net/Core/ScriptMaker.cs
@@ -81,7 +81,7 @@ namespace lighthouse.net.Core
             }
             catch (Exception)
             {
-
+                // ignore
             }
             return false;
         }

--- a/lighthouse.net/Core/TerminalBase.cs
+++ b/lighthouse.net/Core/TerminalBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 

--- a/lighthouse.net/Core/WhereCmd.cs
+++ b/lighthouse.net/Core/WhereCmd.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace lighthouse.net.Core
 {

--- a/lighthouse.net/Lighthouse.cs
+++ b/lighthouse.net/Lighthouse.cs
@@ -1,16 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Net;
 using System.Threading.Tasks;
 using lighthouse.net.Core;
 using lighthouse.net.Objects;
-using System.Runtime.Serialization;
-using System.Runtime.Serialization.Json;
-using System.Text;
 using System.Text.RegularExpressions;
-using Newtonsoft.Json.Linq;
 
 namespace lighthouse.net
 {
@@ -20,10 +13,13 @@ namespace lighthouse.net
         {
             return await Run(new AuditRequest(urlWithProtocol)).ConfigureAwait(false);
         }
-        public async Task<AuditResult> Run(AuditRequest request)
+        public Task<AuditResult> Run(AuditRequest request)
         {
             if (request == null) throw new ArgumentNullException(nameof(request));
-
+            return RunAfterCheck(request);
+        }
+        private async Task<AuditResult> RunAfterCheck(AuditRequest request)
+        {
             var cmd = new WhereCmd()
             {
                 EnableDebugging = request.EnableLogging

--- a/lighthouse.net/Lighthouse.cs
+++ b/lighthouse.net/Lighthouse.cs
@@ -37,8 +37,10 @@ namespace lighthouse.net
             };
             var npmPath = await npm.GetNpmPath().ConfigureAwait(false);
 
+            var version = await npm.GetLighthouseVersion().ConfigureAwait(false);
+
             var sm = new ScriptMaker();
-            var content = sm.Produce(request, npmPath);
+            var content = sm.Produce(request, npmPath, version);
             if (!sm.Save(content)) throw new Exception($"Couldn't save JS script to %temp% directory. Path: {sm.TempFileName}");
 
             try

--- a/lighthouse.net/Objects/AuditRequest.cs
+++ b/lighthouse.net/Objects/AuditRequest.cs
@@ -1,9 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Text;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace lighthouse.net.Objects
 {

--- a/lighthouse.net/Objects/AuditResult.cs
+++ b/lighthouse.net/Objects/AuditResult.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
-using System.Text;
 using Newtonsoft.Json.Linq;
 
 namespace lighthouse.net.Objects

--- a/lighthouse.net/Objects/NpmPackageVersion.cs
+++ b/lighthouse.net/Objects/NpmPackageVersion.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace lighthouse.net.Objects
+{
+    internal class NpmPackageVersion
+    {
+        public NpmPackageVersion(string version)
+        {
+            var arr = version.Split('.');
+            if (arr.Length == 0) throw new ArgumentException("Invalid version");
+            MajorVersion = int.Parse(arr[0]);
+            MinorVersion = int.Parse(arr[1]);
+            PatchVersion = int.Parse(arr[2]);
+        }
+        public int MajorVersion { get; }
+        public int MinorVersion { get; }
+        public int PatchVersion { get; }
+    }
+}

--- a/lighthouse.net/Objects/Screenshot.cs
+++ b/lighthouse.net/Objects/Screenshot.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace lighthouse.net.Objects
+﻿namespace lighthouse.net.Objects
 {
     public struct Screenshot
     {


### PR DESCRIPTION
https://github.com/GoogleChrome/lighthouse/blob/master/docs/emulation.md

Changes made in v7
In Lighthouse v7, most of the configuration regarding emulation changed to be more intuitive and clear. The tracking issue captures additional motivations.

Removed: The emulatedFormFactor property (which determined how emulation is applied).
Removed: The TestedAsMobileDevice artifact. Instead of being inferred, the explicit formFactor property is used.
Removed: The internalDisableDeviceScreenEmulation property. It's equivalent to the new --screenEmulation.disabled=true.
Added: The formFactor property.
Added: The screenEmulation property.
Added: The emulatedUserAgent property.
(throttling and throttlingMethod remain unchanged)